### PR TITLE
HTTP codes removed from returned values in utils.py (fix #15)

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,34 +1,30 @@
-"""Utility features for all backends"""
-from datetime import datetime
+"""Utility features for all backends."""
 import re
+from datetime import datetime
 
 from kytos.core import log
 
 
 def now():
-    '''Return timestamp in ISO-8601 format'''
+    """Return timestamp in ISO-8601 format."""
     return datetime.utcnow().isoformat()
 
 
 def validate_timestamp(start, end):
-    """Method use for validate the time stamp.
-    Avoiding that end be smaller than start.
-    """
+    """Validate timestamp to avoid that end be smaller than start."""
     if start is not None and end is not None:
         start, end = str(start), str(end)
         if start > end:
-            log.error("Invalid Data Range: {}, {}".format(start, end))
-            return 400
+            log.error(f'Error: Invalid Data Range \'{start}, {end}\'')
+            return False
+    return True
 
 
 def iso_format_validation(timestamp):
-    '''
-        Verify if a timestamp is in isoformat.
-        If it's not, try to convert it.
-    '''
-
+    """Verify if a timestamp is in isoformat. If it's not try to convert it."""
     if timestamp is None:
-        return timestamp
+        log.error(f'Error: Timestamp value \'None\' is not valid argument.')
+        return False
 
     if not isinstance(timestamp, str):
         timestamp = str(timestamp)
@@ -51,7 +47,11 @@ def iso_format_validation(timestamp):
             iso = '%Y-%m-%dT%H:%M:%SZ'
             timestamp = datetime.utcfromtimestamp(timestamp).strftime(iso)
         except ValueError:
-            log.error("Error. Timestamp is not is ISO-8601 format.")
-            return 400
-
+            log.error(f'Error: Timestamp value \'{timestamp}\' is not at '
+                      'ISO-8601 format.')
+            return False
+        except OverflowError:
+            log.error(f'Error: Timestamp \'{timestamp}\' float value is too '
+                      'large to be used as datetime.')
+            return False
     return timestamp


### PR DESCRIPTION
- This redefines return values ​​from utils.py module to remove undesired HTTP 
values. This isolates the NApp Kronos from the underlying protocol keeping 
Kronos as an agnostic protocol NApp.
- An exception were added to handle with float values larger than the datetime 
module can handle.