### PR TITLE
Fix Scrutinizer Coverage Error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Overview
 ########
 
+|License| |Build| |Coverage| |Quality|
+
 Attention!
 
 THIS IS AN EXPERIMENTAL NAPP AND ITS EVENTS, METHODS AND STRUCTURES MAY CHANGE A LOT ON THE NEXT FEW DAYS/WEEKS, USE IT AT YOUR OWN DISCERNMENT
@@ -48,3 +50,16 @@ kytos.kronos.delete
 Event requesting to delete data in a namespace from backend.
 
 
+.. TAGs
+
+.. |License| image:: https://img.shields.io/github/license/kytos/kytos.svg
+   :target: https://github.com/kytos/kronos/blob/master/LICENSE
+.. |Build| image:: https://scrutinizer-ci.com/g/kytos/kronos/badges/build.png?b=master
+  :alt: Build status
+  :target: https://scrutinizer-ci.com/g/kytos/kronos/?branch=master
+.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos/kronos/badges/coverage.png?b=master
+  :alt: Code coverage
+  :target: https://scrutinizer-ci.com/g/kytos/kronos/?branch=master
+.. |Quality| image:: https://scrutinizer-ci.com/g/kytos/kronos/badges/quality-score.png?b=master
+  :alt: Code-quality score
+  :target: https://scrutinizer-ci.com/g/kytos/kronos/?branch=master

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
 astroid==2.0.4            # via pylint
 click==6.7                # via pip-tools
-coverage==4.5.1
+coverage==5.0.3
 docopt==0.6.2             # via yala
 first==2.0.1              # via pip-tools
 isort==4.3.4              # via pylint, yala


### PR DESCRIPTION
The coverage version was creating an error when running Scrutinizer.
This commit changes coverage version from 4.5.1 to 5.0.3 and add some badges in README.