### PR TITLE
Create .coveragerc to enable coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = .
+omit = *tests*,.tox/*,setup.py


### PR DESCRIPTION
Today, Kronos napp doesn't have a .coveragerc. This commit creates this file, enabling Scrutinizer.