### PR TITLE
Add check to timestamp value

### DIFF
--- a/backends/influx.py
+++ b/backends/influx.py
@@ -88,7 +88,9 @@ class InfluxBackend:
             raise ValueConvertError(error)
 
         timestamp = timestamp or now()
-        if iso_format_validation(timestamp) is False:
+
+        if iso_format_validation(timestamp) is False \
+                or isinstance(timestamp, (int, float)):
             timestamp = convert_to_iso(timestamp)
 
         data = [{

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,8 +23,8 @@ docutils==0.16            # via sphinx
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-metadata==1.7.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 isort==4.3.21             # via pylint, yala
 jinja2==2.11.1            # via sphinx
 lazy-object-proxy==1.4.3  # via astroid
@@ -39,14 +39,14 @@ pluggy==0.13.1            # via pytest, tox
 port_for==0.3.1           # via sphinx-autobuild
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0        # via yala
-pygments==2.6.1           # via sphinx
+pygments==2.7.1           # via sphinx
 pylint==2.4.4             # via yala
 pyparsing==2.4.6          # via packaging
 pytest==5.4.1             # via -r requirements/dev.in
 pytz==2019.3              # via babel
 pyyaml==5.3.1             # via sphinx-autobuild
 requests==2.23.0          # via sphinx
-six==1.14.0               # via astroid, livereload, packaging, pip-tools, tox, virtualenv
+six==1.15.0               # via astroid, livereload, packaging, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via sphinx
 sphinx-autobuild==0.7.1   # via kytos-sphinx-theme
 sphinx==2.0.1             # via kytos-sphinx-theme
@@ -66,7 +66,7 @@ watchdog==0.10.2          # via sphinx-autobuild
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid
 yala==2.2.0               # via -r requirements/dev.in
-zipp==3.1.0               # via importlib-metadata, importlib-resources
+zipp==3.3.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION

### :octocat: Are you working on some issue? Identify the issue!

This PR fix issue #44 


### :bookmark_tabs: Description of the Change

This PR adds a check if the timestamp is an int or float value, if it is true
the method 'convert_to_iso' is called and is not necessary check if the timestamp
are in iso format.

### :computer: Verification Process

Tested manually using kytos/of_stats to send an event to kytos/kronos.

### :page_facing_up: Release Notes

N/A