### PR TITLE
Add support to kronos save dictionary received from an event.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,6 +39,7 @@ pluggy==0.13.1            # via pytest, tox
 port_for==0.3.1           # via sphinx-autobuild
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0        # via yala
+pydocstyle==5.1.1         # via -r requirements/dev.in
 pygments==2.7.1           # via sphinx
 pylint==2.4.4             # via yala
 pyparsing==2.4.6          # via packaging

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,8 @@ class TestCoverage(Test):
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
             print(exc)
+            print('Coverage tests failed. Fix the errors above and try again.')
+            sys.exit(-1)
 
 
 class Linter(SimpleCommand):

--- a/tests/unit/test_influxbackend.py
+++ b/tests/unit/test_influxbackend.py
@@ -204,8 +204,8 @@ class TestInfluxBackend(TestCase):
                 '_write_endpoints')
     def test_save_success(self, mock_influx_write_endpoints):
         """Test to check the success in data storage in Influx Backend."""
-        namespace = 'kytos.kronos.telemetry.switches.1.interfaces.232.bytes_in'
-        value = '1234'
+        namespace = 'kytos.kronos.telemetry.switches.1.interfaces.232'
+        value = {'bytes_in': 1234}
         timestamp = '0'
         self.backend.save(namespace, value, timestamp)
 
@@ -222,8 +222,8 @@ class TestInfluxBackend(TestCase):
 
     def test_save_fail_invalid_value(self):
         """Test fail case in save with invalid value."""
-        namespace = 'kytos.kronos.telemetry.switches.1.interfaces.232.bytes_in'
-        value = 'abc'
+        namespace = 'kytos.kronos.telemetry.switches.1.interfaces.232'
+        value = {'bytes_in': 'abc'}
         timestamp = '1970-01-02T10:17:36Z'
 
         with self.assertRaises(ValueConvertError):


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Fix issue #46 

### :bookmark_tabs: Description of the Change

This PR adds support to influx backend save a dictionary. This modification will reduce the number of events received from 'kytos/of_stats'. Besides that adds the pydocstyle to requirements. 

### :computer: Verification Process

Verification was executed with of_stats and influxdb manuallt

### :page_facing_up: Release Notes

The event save now receives a dictionary in value field.
