### PR TITLE
Replace the exception ValueConvertError by ValueError to simplify code.

### DIFF
--- a/backends/influx.py
+++ b/backends/influx.py
@@ -6,9 +6,8 @@ from influxdb import InfluxDBClient, exceptions
 from kytos.core import log
 # pylint: disable=import-error,wrong-import-order
 from napps.kytos.kronos.utils import (BackendError, NamespaceError,
-                                      ValueConvertError, convert_to_iso,
-                                      iso_format_validation, now,
-                                      validate_timestamp)
+                                      convert_to_iso, iso_format_validation,
+                                      now, validate_timestamp)
 
 
 def _query_assemble(clause, namespace, start, end, field=None,
@@ -82,9 +81,9 @@ class InfluxBackend:
             for key, stat in data_to_save.items():
                 data_to_save[key] = float(stat)
         except ValueError:
-            error = (f'It is not possible convert the sent to be saved '
-                     'to float.')
-            raise ValueConvertError(error)
+            error = (f"Could not convert {type(stat)} to float: '{stat}' "
+                     f"for key '{key}'.")
+            raise ValueError(error)
 
         _validate_namespace(namespace)
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from kytos.core.helpers import listen_to
 from napps.kytos.kronos import settings
 from napps.kytos.kronos.backends.csvbackend import CSVBackend
 from napps.kytos.kronos.backends.influx import InfluxBackend
-from napps.kytos.kronos.utils import NamespaceError, ValueConvertError
+from napps.kytos.kronos.utils import NamespaceError
 
 
 class Main(KytosNApp):
@@ -32,7 +32,7 @@ class Main(KytosNApp):
         """Save the data in one of the backends."""
         try:
             self.backend.save(namespace, value, timestamp)
-        except (NamespaceError, ValueConvertError) as exc:
+        except (NamespaceError, ValueError) as exc:
             exc_name = exc.__class__.__name__
             return jsonify({'exc_name': exc_name, 'response': str(exc)})
 
@@ -46,7 +46,7 @@ class Main(KytosNApp):
         """Delete the data in one of the backends."""
         try:
             self.backend.delete(namespace, start, end)
-        except (NamespaceError, ValueConvertError, ValueError) as exc:
+        except (NamespaceError, ValueError, ValueError) as exc:
             exc_name = exc.__class__.__name__
             return jsonify({'exc_name': exc_name, 'response': str(exc)})
 
@@ -68,7 +68,7 @@ class Main(KytosNApp):
         try:
             result = self.backend.get(namespace, start, end, method, fill,
                                       group)
-        except (NamespaceError, ValueConvertError, ValueError) as exc:
+        except (NamespaceError, ValueError, ValueError) as exc:
             exc_name = exc.__class__.__name__
             return jsonify({'exc_name': exc_name, 'response': str(exc)})
 
@@ -85,7 +85,7 @@ class Main(KytosNApp):
                               event.content['value'],
                               event.content['timestamp'])
             result = 'Value saved.'
-        except (NamespaceError, ValueConvertError) as exc:
+        except (NamespaceError, ValueError) as exc:
             error = (exc.__class__.__name__, str(exc))
 
         self._execute_callback(event, result, error)
@@ -99,7 +99,7 @@ class Main(KytosNApp):
             result = self.backend.get(event.content['namespace'],
                                       event.content['start'],
                                       event.content['end'])
-        except (NamespaceError, ValueConvertError, ValueError) as exc:
+        except (NamespaceError, ValueError, ValueError) as exc:
             error = (exc.__class__.__name__, str(exc))
 
         self._execute_callback(event, result, error)
@@ -114,7 +114,7 @@ class Main(KytosNApp):
                                 event.content['start'],
                                 event.content['end'])
             result = 'Value deleted.'
-        except (NamespaceError, ValueConvertError, ValueError) as exc:
+        except (NamespaceError, ValueError, ValueError) as exc:
             error = (exc.__class__.__name__, str(exc))
 
         self._execute_callback(event, result, error)

--- a/tests/unit/test_influxbackend.py
+++ b/tests/unit/test_influxbackend.py
@@ -15,8 +15,7 @@ sys.modules['influxdb'] = mock.MagicMock()
 sys.modules['influxdb.exceptions'] = mock.MagicMock()
 
 import napps.kytos.kronos.backends.influx as influx
-from napps.kytos.kronos.utils import (BackendError, NamespaceError,
-                                      ValueConvertError)
+from napps.kytos.kronos.utils import (BackendError, NamespaceError)
 
 # pylint: enable=wrong-import-order,wrong-import-position
 # pylint: disable=R0904,E0012, Too many public methods
@@ -226,7 +225,7 @@ class TestInfluxBackend(TestCase):
         value = {'bytes_in': 'abc'}
         timestamp = '1970-01-02T10:17:36Z'
 
-        with self.assertRaises(ValueConvertError):
+        with self.assertRaises(ValueError):
             self.backend.save(namespace, value, timestamp)
 
     @mock.patch('napps.kytos.kronos.backends.influx.InfluxBackend.'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -12,7 +12,7 @@ from flask import Flask
 sys.modules['influxdb'] = mock.MagicMock()
 
 from napps.kytos.kronos.main import Main
-from napps.kytos.kronos.utils import (NamespaceError, ValueConvertError)
+from napps.kytos.kronos.utils import (NamespaceError)
 from tests.helpers import get_controller_mock
 
 # pylint: enable=wrong-import-order,wrong-import-position
@@ -60,13 +60,13 @@ class TestMainKronos(TestCase):
         value = '123'
         timestamp = 'abc'
 
-        mock_influx_save.side_effect = ValueConvertError()
+        mock_influx_save.side_effect = ValueError()
 
         app = Flask(__name__)
         with app.app_context():
             response = self.napp.rest_save(namespace, value, timestamp)
             exception_name = response.json['exc_name']
-            self.assertEqual(exception_name, 'ValueConvertError')
+            self.assertEqual(exception_name, 'ValueError')
 
     @mock.patch('napps.kytos.kronos.main.InfluxBackend.delete')
     def test_rest_delete_success_with_influx(self, mock_influx_delete):
@@ -102,13 +102,13 @@ class TestMainKronos(TestCase):
         start = 'abc'
         end = 123457
 
-        mock_influx_del.side_effect = ValueConvertError()
+        mock_influx_del.side_effect = ValueError()
 
         app = Flask(__name__)
         with app.app_context():
             response = self.napp.rest_delete(namespace, start, end)
             exception_name = response.json['exc_name']
-            self.assertEqual(exception_name, 'ValueConvertError')
+            self.assertEqual(exception_name, 'ValueError')
 
     @mock.patch('napps.kytos.kronos.main.InfluxBackend.delete')
     def test_rest_delete_failed_invalid_timestamp_range(self, mock_influx_del):
@@ -164,13 +164,13 @@ class TestMainKronos(TestCase):
         start = 'abc'
         end = 11111
 
-        mock_influx_get.side_effect = ValueConvertError()
+        mock_influx_get.side_effect = ValueError()
 
         app = Flask(__name__)
         with app.app_context():
             response = self.napp.rest_get(namespace, start, end)
             exception_name = response.json['exc_name']
-            self.assertEqual(exception_name, 'ValueConvertError')
+            self.assertEqual(exception_name, 'ValueError')
 
     @mock.patch('napps.kytos.kronos.main.InfluxBackend.get')
     def test_rest_get_fail_with_invalid_timestamp_range(self, mock_influx_get):
@@ -243,12 +243,12 @@ class TestMainKronos(TestCase):
                          'timestamp': timestamp}
 
         # Values expected to call '_execute_callback'
-        exc = ValueConvertError()
+        exc = ValueError()
         error = (exc.__class__.__name__, str(exc))
         result = None
 
         # Set a exception to mocked function return value
-        mock_influx_save.side_effect = ValueConvertError()
+        mock_influx_save.side_effect = ValueError()
 
         self.napp.event_save(event)
         mock_callback.assert_called_with(event, result, error)
@@ -312,12 +312,12 @@ class TestMainKronos(TestCase):
                          'end': end}
 
         # Values expected to call '_execute_callback'
-        exc = ValueConvertError()
+        exc = ValueError()
         error = (exc.__class__.__name__, str(exc))
         result = None
 
         # Set a exception to mocked function return value
-        mock_influx_get.side_effect = ValueConvertError()
+        mock_influx_get.side_effect = ValueError()
 
         self.napp.event_get(event)
         mock_callback.assert_called_with(event, result, error)
@@ -404,12 +404,12 @@ class TestMainKronos(TestCase):
                          'end': end}
 
         # Values expected to call '_execute_callback'
-        exc = ValueConvertError()
+        exc = ValueError()
         error = (exc.__class__.__name__, str(exc))
         result = None
 
         # Set a exception to mocked function return value
-        mock_influx_del.side_effect = ValueConvertError()
+        mock_influx_del.side_effect = ValueError()
 
         self.napp.event_delete(event)
         mock_callback.assert_called_with(event, result, error)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,8 +4,7 @@ Unit tests to check fail and success cases in utils module.
 """
 from unittest import TestCase
 
-from napps.kytos.kronos.utils import (ValueConvertError, convert_to_iso,
-                                      iso_format_validation,
+from napps.kytos.kronos.utils import (convert_to_iso, iso_format_validation,
                                       validate_timestamp)
 
 
@@ -27,14 +26,14 @@ class TestMainKronos(TestCase):
         """Test fail case in method convert_to_iso with an invalid value."""
         timestamp = 'abc'
 
-        with self.assertRaises(ValueConvertError):
+        with self.assertRaises(ValueError):
             convert_to_iso(timestamp)
 
     def test_convert_to_iso_failed_with_large_value(self):
         """Test fail case in method convert_to_iso with a value too large."""
         timestamp = 10**100
 
-        with self.assertRaises(ValueConvertError):
+        with self.assertRaises(ValueError):
             convert_to_iso(timestamp)
 
     def test_validate_timestamp_success(self):

--- a/utils.py
+++ b/utils.py
@@ -11,10 +11,6 @@ class NamespaceError(Exception):
     """Exception thrown when the provided namespace is not valid."""
 
 
-class ValueConvertError(Exception):
-    """Exception thrown when it is not possible convert the value to stored."""
-
-
 def now():
     """Return timestamp in ISO-8601 format."""
     return datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -39,11 +35,11 @@ def convert_to_iso(timestamp):
     except ValueError:
         error = f'Error: Timestamp value \'{timestamp}\' is not convertible'\
                  ' to ISO-8601 format.'
-        raise ValueConvertError(error)
+        raise ValueError(error)
     except OverflowError:
         error = f'Error: Timestamp \'{timestamp}\' float value is too '\
                  'large to be used as datetime.'
-        raise ValueConvertError(error)
+        raise ValueError(error)
 
 
 def iso_format_validation(timestamp):


### PR DESCRIPTION
# Pull Request Template


### :bookmark_tabs: Description of the Change

This PR replace the too specific exception ValueConvertError by ValueError. This decision were made to simplify the code and avoid create too specific exception with no specific treatment.

### :computer: Verification Process

Unit tests

### :page_facing_up: Release Notes

"N/A"
