### PR TITLE
Increase the 'pool_size' to remove "connection pool is full" warnings

### DIFF
--- a/backends/influx.py
+++ b/backends/influx.py
@@ -156,7 +156,8 @@ class InfluxBackend:
                   'PORT': '8086',
                   'DBNAME': None,
                   'USER': None,
-                  'PASS': None}
+                  'PASS': None,
+                  'POOL_SIZE': 100}
         config = settings.BACKENDS.get('INFLUXDB')
 
         for key in params:
@@ -170,13 +171,15 @@ class InfluxBackend:
         self._username = params['USER']
         self._password = params['PASS']
         self._database = params['DBNAME']
+        self._pool_size = params['POOL_SIZE']
 
     def _start_client(self):
         self._client = InfluxDBClient(host=self._host,
                                       port=self._port,
                                       username=self._username,
                                       password=self._password,
-                                      database=self._database)
+                                      database=self._database,
+                                      pool_size=self._pool_size)
 
     def _create_database(self):
         self._client.create_database(self._database)

--- a/settings.py
+++ b/settings.py
@@ -7,7 +7,8 @@ BACKENDS['INFLUXDB'] = {
     'PASS': 'bar',
     'PORT': 8086,
     'HOST': 'localhost',
-    'DBNAME': 'teste_kytos'
+    'DBNAME': 'kytos',
+    'POOL_SIZE': 100
 }
 BACKENDS['CSV'] = {
     'USER': 'foo',


### PR DESCRIPTION
Set the pool_size as 100 to increase the number of connections at pool
and avoid the lost of statistics sent to influx to be saved. The default value
of 10 connections are enough to deal with the requests from of_stats, 
which causes the following warning:
`2021-04-16 17:17:50,300 - WARNING [urllib3.connectionpool] (Thread-234) Connection pool is full, discarding connection: localhost`